### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 django-image-cropping
 =====================
 
-.. image:: https://pypip.in/v/django-image-cropping/badge.png
+.. image:: https://img.shields.io/pypi/v/django-image-cropping.svg
     :target: https://pypi.python.org/pypi/django-image-cropping
 
 .. image:: https://travis-ci.org/jonasundderwolf/django-image-cropping.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-image-cropping-amazon-s3))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-image-cropping-amazon-s3`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.